### PR TITLE
Fix audio file path resolution for Flet asset loading

### DIFF
--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -19,10 +19,10 @@ class AudioEngine:
     
     def play_sample(self, path: str, sustain: bool = False, gain: float = 1.0) -> str:
         """Play audio sample and return voice ID"""
-        if not Path(path).exists():
-            print(f"Warning: Audio file not found: {path}")
-            path = "assets/audio/C_Ionian_I_maj_drop2_root__oct4.wav"
-            if not Path(path).exists():
+        if not Path(f"assets/{path}").exists():
+            print(f"Warning: Audio file not found: assets/{path}")
+            path = "audio/C_Ionian_I_maj_drop2_root__oct4.wav"
+            if not Path(f"assets/{path}").exists():
                 print("Error: No audio samples available")
                 return "error"
         

--- a/app/core/theory.py
+++ b/app/core/theory.py
@@ -73,4 +73,4 @@ def chord_to_asset_path(key_setting: KeySetting, degree_idx: int) -> str:
                 f"{key_setting.voicing}_{key_setting.inversion}_"
                 f"{tensions_str}_oct{key_setting.octave_base}.wav")
     
-    return f"assets/audio/{filename}"
+    return f"audio/{filename}"

--- a/main.py
+++ b/main.py
@@ -147,4 +147,4 @@ def main(page: ft.Page):
     update_status()
 
 if __name__ == "__main__":
-    ft.app(main)
+    ft.app(main, assets_dir="assets")


### PR DESCRIPTION
- Remove 'assets/' prefix from audio paths in theory.py and audio.py
- Add explicit assets_dir='assets' parameter to ft.app() for clarity
- Fix Path.exists() checks to use correct asset directory path
- Paths should be relative to assets_dir per Flet documentation

Fixes audio playback issue where chord pads were silent in desktop mode. Root cause: Flet looks for assets relative to assets_dir, so 'assets/audio/file.wav' was being resolved to 'assets/assets/audio/file.wav' which doesn't exist.